### PR TITLE
[WIP] Add experimental C API for long-lived GPIs.

### DIFF
--- a/rl/easy21/src/shortcuts.rs
+++ b/rl/easy21/src/shortcuts.rs
@@ -6,7 +6,9 @@ use sarsa::SarsaLambda;
 use lfa::LinearFunctionApproximator;
 use game::RngDeck;
 
-pub fn run_monte_carlo(episodes: i32) -> Gpi<RngDeck<StdRng>, EpsilonGreedyPolicy<StdRng, MonteCarlo>> {
+pub type MonteCarloGpi = Gpi<RngDeck<StdRng>, EpsilonGreedyPolicy<StdRng, MonteCarlo>>;
+
+pub fn run_monte_carlo(episodes: i32) -> MonteCarloGpi {
     let seed: &[_] = &[1, 2, 3, 4];
     let rng: StdRng = SeedableRng::from_seed(seed);
     let deck = RngDeck::new(rng);
@@ -14,7 +16,9 @@ pub fn run_monte_carlo(episodes: i32) -> Gpi<RngDeck<StdRng>, EpsilonGreedyPolic
     let policy = EpsilonGreedyPolicy::new(rng, mc_alg);
     let mut gpi = Gpi::new(deck, policy);
 
-    gpi.play_episodes(episodes);
+    if episodes > 0 {
+        gpi.play_episodes(episodes);
+    }
 
     gpi
 }


### PR DESCRIPTION
Right now graphing a value function's mean squared error across episodes is hard because of the fact that the C API wasn't really designed for it.  This is an attempt to add long-lived GPI objects to the C API that allows such calculations to be more efficient.