### PR TITLE
Provide a get_next_action() cb to on_episode_step()

### DIFF
--- a/rl/easy21/src/c_api.rs
+++ b/rl/easy21/src/c_api.rs
@@ -21,7 +21,7 @@ pub extern "C" fn get_output_size() -> c_int {
     OUTPUT_SIZE as i32
 }
 
-fn write_expected_reward_matrix(alg: &Alg, output: *mut c_float) {
+fn write_expected_reward_matrix<T: Alg>(alg: &T, output: *mut c_float) {
     let mut i = 0;
 
     for dealer in MIN_CARD..MAX_CARD + 1 {
@@ -49,12 +49,12 @@ fn run_gpi<T: Deck, U: Rng, V: Alg>(
     match cb {
         None => {
             gpi.play_episodes(episodes);
-            write_expected_reward_matrix(&gpi.policy.alg, output);
+            write_expected_reward_matrix(gpi.policy.alg.get_mut(), output);
         },
         Some(func) => {
             for _ in 0..episodes {
                 gpi.play_episode();
-                write_expected_reward_matrix(&gpi.policy.alg, output);
+                write_expected_reward_matrix(gpi.policy.alg.get_mut(), output);
                 func();
             }
         }

--- a/rl/easy21/src/lfa.rs
+++ b/rl/easy21/src/lfa.rs
@@ -43,9 +43,11 @@ impl Alg for LinearFunctionApproximator {
         self.traces.drain();
     }
 
-    fn on_episode_step(&mut self, state: State, action: Action,
-                       reward: Reward, next_state: State,
-                       next_action: Action) -> Option<Action> {
+    fn on_episode_step<F>(&mut self, state: State, action: Action,
+                          reward: Reward, next_state: State,
+                          get_next_action: F) -> Option<Action>
+        where F: Fn() -> Action {
+        let next_action = get_next_action();
         let td_error = reward +
                        self.get_expected_reward(next_state, next_action) -
                        self.get_expected_reward(state, action);

--- a/rl/easy21/src/main.rs
+++ b/rl/easy21/src/main.rs
@@ -15,7 +15,7 @@ fn run_monte_carlo(episodes: i32) {
 
     let gpi = shortcuts::run_monte_carlo(episodes);
 
-    gpi.policy.alg.print_optimal_values();
+    gpi.policy.alg.borrow().print_optimal_values();
 }
 
 fn run_sarsa(episodes: i32, lambda: f32) {
@@ -27,7 +27,7 @@ fn run_sarsa(episodes: i32, lambda: f32) {
 
     let gpi = shortcuts::run_sarsa(episodes, lambda);
 
-    gpi.policy.alg.print_optimal_values();
+    gpi.policy.alg.borrow().print_optimal_values();
 }
 
 fn run_lfa(episodes: i32, lambda: f32) {
@@ -41,7 +41,7 @@ fn run_lfa(episodes: i32, lambda: f32) {
     let step_size = 0.01;
     let gpi = shortcuts::run_lfa(episodes, lambda, epsilon, step_size);
 
-    gpi.policy.alg.print_optimal_values();
+    gpi.policy.alg.borrow().print_optimal_values();
 }
 
 fn validate_episodes(v: String) -> Result<(), String> {

--- a/rl/easy21/src/montecarlo.rs
+++ b/rl/easy21/src/montecarlo.rs
@@ -41,9 +41,9 @@ impl Alg for MonteCarlo {
         self.visited_this_episode.drain();
     }
 
-    fn on_episode_step(&mut self, state: State, action: Action,
-                       reward: Reward, _next_state: State,
-                       _next_action: Action) -> Option<Action> {
+    fn on_episode_step<F>(&mut self, state: State, action: Action,
+                          reward: Reward, _next_state: State,
+                          _get_next_action: F) -> Option<Action> {
         // We only care about the *first* time a state/action pair
         // was visited in an episode.
         self.visited_this_episode.entry((state, action)).or_insert(true);

--- a/rl/easy21/src/sarsa.rs
+++ b/rl/easy21/src/sarsa.rs
@@ -42,10 +42,12 @@ impl Alg for SarsaLambda {
         self.traces.drain();
     }
 
-    fn on_episode_step(&mut self, state: State, action: Action,
-                       reward: Reward, next_state: State,
-                       next_action: Action) -> Option<Action> {
+    fn on_episode_step<F>(&mut self, state: State, action: Action,
+                          reward: Reward, next_state: State,
+                          get_next_action: F) -> Option<Action>
+        where F: Fn() -> Action {
         let step_size = self.step_sizer.update(state, action);
+        let next_action = get_next_action();
         let td_error = reward +
                        self.get_expected_reward(next_state, next_action) -
                        self.get_expected_reward(state, action);


### PR DESCRIPTION
Arg, yet another failed attempt at fighting with the borrow checker.

Here I tried using `RefCell`s to make it possible to pass a `get_next_action()` callback to `on_episode_step()`, and while it compiles, it fails at runtime because `get_next_action()` needs to immutably borrow `self.alg`, which is already being mutably borrowed.
